### PR TITLE
added command return and _get_line() helper

### DIFF
--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -22,6 +22,7 @@ SYMBOLS_REPLACEMENT = {
     ">": "GREATER",
     "|": "PIPE",
     " ": "SPACE",
+    "\r": "RETURN",
     "@": "AT",
     "$": "DOLLAR",
     "0": "ZERO",
@@ -94,6 +95,16 @@ class VimKeys(object):
 
     def SPACE(self, repeat=1):
         self._move_cursor(QTextCursor.Right, repeat)
+
+    def RETURN(self, repeat=1):
+        editor = self._widget.editor()
+        cursor = editor.textCursor()
+        cursor.movePosition(QTextCursor.NextBlock, n=repeat)
+        text = self._get_line(cursor)
+        if not text.isspace() and text[0].isspace():
+            cursor.movePosition(QTextCursor.NextWord)
+        editor.setTextCursor(cursor)
+        self._widget.update_vim_cursor()
 
     def DOLLAR(self, repeat=1):
         self._move_cursor(QTextCursor.EndOfLine)
@@ -283,6 +294,9 @@ class VimLineEdit(QLineEdit):
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Escape:
             self.clear()
+        elif event.key() == Qt.Key_Return:
+            self.setText(self.text() + "\r")
+            self.parent().on_return()
         else:
             QLineEdit.keyPressEvent(self, event)
 

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -60,15 +60,17 @@ class VimKeys(object):
         return cursor
 
     def _get_line(self, editor_cursor, lines=1):
+        """Return the line at cursor position."""
         try:
             cursor = QTextCursor(editor_cursor)
+        except TypeError:
+            print("ERROR: editor_cursor must be an instance of QTextCursor")
+        else:
             cursor.movePosition(QTextCursor.StartOfLine)
             cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor,
                                 n=lines)
             line = cursor.selectedText()
             return line
-        except (TypeError, AttributeError):
-            print("ERROR: editor_cursor must be an instance of QTextCursor")
 
     # %% Movement
     def h(self, repeat=1):

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -56,7 +56,18 @@ class VimKeys(object):
         editor = self._widget.editor()
         cursor = editor.textCursor()
         return cursor
-        
+
+    def _get_line(self, editor_cursor, lines=1):
+        try:
+            cursor = QTextCursor(editor_cursor)
+            cursor.movePosition(QTextCursor.StartOfLine)
+            cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor,
+                                n=lines)
+            line = cursor.selectedText()
+            return line
+        except (TypeError, AttributeError):
+            print("ERROR: editor_cursor must be an instance of QTextCursor")
+
     # %% Movement
     def h(self, repeat=1):
         cursor = self._editor_cursor()
@@ -104,7 +115,7 @@ class VimKeys(object):
     # %% Insertion
     def i(self, repeat):
         self._widget.editor().setFocus()
-        
+
     def I(self, repeat):
         self._move_cursor(QTextCursor.StartOfLine)
         self._widget.editor().setFocus()
@@ -147,6 +158,10 @@ class VimKeys(object):
         cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor, repeat)
         editor.setTextCursor(cursor)
         editor.cut()
+        text = self._get_line(cursor)
+        if not text.isspace() and text[0].isspace():
+            cursor.movePosition(QTextCursor.NextWord)
+        editor.setTextCursor(cursor)
         self._widget.update_vim_cursor()
 
     def D(self, repeat):
@@ -174,11 +189,8 @@ class VimKeys(object):
 
     # %% Copy
     def yy(self, repeat):
-        editor = self._widget.editor()
-        cursor = editor.textCursor()
-        cursor.movePosition(QTextCursor.StartOfLine)
-        cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor, repeat)
-        text = cursor.selectedText()
+        cursor = self._editor_cursor()
+        text = self._get_line(cursor, lines=repeat)
         QApplication.clipboard().setText(text)
 
     def yw(self, repeat):

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -101,7 +101,9 @@ class VimKeys(object):
         cursor = editor.textCursor()
         cursor.movePosition(QTextCursor.NextBlock, n=repeat)
         text = self._get_line(cursor)
-        if not text.isspace() and text[0].isspace():
+        if text.isspace() or not text:
+            pass
+        elif text[0].isspace():
             cursor.movePosition(QTextCursor.NextWord)
         editor.setTextCursor(cursor)
         self._widget.update_vim_cursor()
@@ -170,7 +172,9 @@ class VimKeys(object):
         editor.setTextCursor(cursor)
         editor.cut()
         text = self._get_line(cursor)
-        if not text.isspace() and text[0].isspace():
+        if text.isspace() or not text:
+            pass
+        elif text[0].isspace():
             cursor.movePosition(QTextCursor.NextWord)
         editor.setTextCursor(cursor)
         self._widget.update_vim_cursor()

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -22,8 +22,8 @@ SYMBOLS_REPLACEMENT = {
     ">": "GREATER",
     "|": "PIPE",
     " ": "SPACE",
-    "\r": "RETURN",
     "\b": "BACKSPACE",
+    "\r": "RETURN",
     "@": "AT",
     "$": "DOLLAR",
     "0": "ZERO",
@@ -97,6 +97,9 @@ class VimKeys(object):
     def SPACE(self, repeat=1):
         self._move_cursor(QTextCursor.Right, repeat)
 
+    def BACKSPACE(self, repeat=1):
+        self._move_cursor(QTextCursor.Left, repeat)
+
     def RETURN(self, repeat=1):
         editor = self._widget.editor()
         cursor = editor.textCursor()
@@ -108,9 +111,6 @@ class VimKeys(object):
             cursor.movePosition(QTextCursor.NextWord)
         editor.setTextCursor(cursor)
         self._widget.update_vim_cursor()
-
-    def BACKSPACE(self, repeat=1):
-        self._move_cursor(QTextCursor.Left, repeat)
 
     def DOLLAR(self, repeat=1):
         self._move_cursor(QTextCursor.EndOfLine)
@@ -302,11 +302,11 @@ class VimLineEdit(QLineEdit):
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Escape:
             self.clear()
+        elif event.key() == Qt.Key_Backspace:
+            self.setText(self.text() + "\b")
         elif event.key() == Qt.Key_Return:
             self.setText(self.text() + "\r")
             self.parent().on_return()
-        elif event.key() == Qt.Key_Backspace:
-            self.setText(self.text() + "\b")
         else:
             QLineEdit.keyPressEvent(self, event)
 


### PR DESCRIPTION
Pressing return goes to the beginning of the next line.
The _get_line() helper function gets a cursor's current line.

Moving the cursor to start of the first word of a line is common in Vim, so a helper function may be useful for that as well.