### PR TITLE
Visual mode added

### DIFF
--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -176,7 +176,9 @@ class VimKeys(object):
         elif self.visual_mode == 'line':
             start, end = self._get_selection_positions()
             cur_block = cursor.block()
-            if cursor.position() < start:
+            if start == 0:
+                pass
+            elif cursor.position() < start:
                 self._move_selection(cur_block.position(), move_start=True)
             else:
                 self._move_selection(cur_block.next().position())
@@ -238,6 +240,20 @@ class VimKeys(object):
         editor = self._widget.editor()
         editor.go_to_line(repeat)
         self._widget.update_vim_cursor()
+        if self.visual_mode:
+            start, stop = self._get_selection_positions()
+            cursor = self._editor_cursor()
+            cur_block = cursor.block()
+            if cursor.position() < start:
+                if self.visual_mode == 'line':
+                    self._move_selection(cursor.position(), move_start=True)
+                else:
+                    self._move_selection(cur_block.position(), move_start=True)
+            else:
+                if self.visual_mode == 'line':
+                    self._move_selection(cur_block.next().position())
+                else:
+                    self._move_selection(cursor.position())
 
     # %% Insertion
     def i(self, repeat):

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -81,9 +81,9 @@ class VimKeys(object):
         if self.visual_mode == 'line':
             prev_cursor_block = self._prev_cursor.block()
             if move_start:
-                prev_cursor_block = prev_cursor_block.next()
+                next_cursor_block = prev_cursor_block.next()
                 selection.cursor.setPosition(pos)
-                selection.cursor.setPosition(prev_cursor_block.position(),
+                selection.cursor.setPosition(next_cursor_block.position(),
                                              QTextCursor.KeepAnchor)
             else:
                 selection.cursor.setPosition(prev_cursor_block.position())
@@ -143,8 +143,9 @@ class VimKeys(object):
         elif self.visual_mode == 'line':
             start, end = self._get_selection_positions()
             cur_block = cursor.block()
-            if cursor.position() > end:
-                self._move_selection(cur_block.next().position())
+            if cursor.position() >= end:
+                if not cursor.atEnd():
+                    self._move_selection(cur_block.next().position())
             else:
                 self._move_selection(cur_block.position(), move_start=True)
 


### PR DESCRIPTION
Added visual mode. #4 

So far v and V work, so text can be selected by character or line.
ctrl + v has not been added, so block selection is not available.

Commands h, j, k, l, w, G, and y added to visual mode.

#### Note:
This PR is based off of #16 since most of visual mode's features are related to yanking text and pasting and the selection types must be tracked.

