### PR TITLE
PR: Fix "a" behavior at the end of block

### DIFF
--- a/spyder_vim/tests/test_vim.py
+++ b/spyder_vim/tests/test_vim.py
@@ -1090,6 +1090,14 @@ def test_a_command(vim_bot):
     new_line, new_col = editor.get_cursor_line_column()
     assert new_col == col + 1
 
+    # At BlockEnd
+    editor.moveCursor(QTextCursor.EndOfLine, QTextCursor.KeepAnchor)
+    cmd_line = vim.get_focus_widget()
+    line, col = editor.get_cursor_line_column()
+    qtbot.keyClicks(cmd_line, 'a')
+    new_line, new_col = editor.get_cursor_line_column()
+    assert new_col == col
+
 
 def test_uppercase_a_command(vim_bot):
     """Append text at the end of the line."""

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -587,7 +587,7 @@ class VimKeys(QObject):
     def a(self, leftover=None, repeat=1):
         """Append text after the cursor."""
         if not leftover:
-            self.l()
+            self._move_cursor(QTextCursor.Right)
             self._widget.editor().setFocus()
         elif leftover in list("\"\'([{<>}])"):
             editor = self._widget.editor()


### PR DESCRIPTION
- Fixed the cursor behavior in Normal mode at end of line when 'a' command.
