### PR TITLE
PR: Add initial contributing guide and release steps docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to the Spyder Vim plugin
+
+:+1::tada: 
+First off, thanks for taking the time to contribute to the Spyder Vim
+plugin! 
+:tada::+1:
+
+## General guidelines for contributing
+
+The Spyder Vim plugin is developed as part of the wider Spyder project.
+In general, the guidelines for contributing to Spyder also apply here.
+Specifically, all contributors are expected to abide by
+[Spyder's Code of Conduct](https://github.com/spyder-ide/spyder/blob/master/CODE_OF_CONDUCT.md).
+
+There are many ways to contribute and all are valued and welcome. 
+You can help other users, write documentation, spread the word, submit
+helpful issues on the
+[issue tracker](https://github.com/spyder-ide/spyder-vim/issues)
+with problems you encounter or ways to improve the plugin, test the development
+version, or submit a pull request on GitHub.
+
+The rest of this document explains how to set up a development environment.
+
+## Setting up a development environment
+
+This section explains how to set up a conda environment to run and work on the
+development version of the Spyder vim plugin.
+
+### Creating a conda environment
+
+This creates a new conda environment with the name `spydervim-dev`.
+
+```bash
+$ conda create -n spydervim-dev -c conda-forge python=3.9
+$ conda activate spydervim-dev
+```
+
+### Cloning the repository
+
+This creates a new directory `spyder-vim` with the source code of the
+Spyder Vim plugin.
+
+```bash
+$ git clone https://github.com/spyder-ide/spyder-vim.git
+$ cd spyder-vim
+```
+
+### Installing dependencies
+
+This installs Spyder, QtPy and all other dependencies of the plugin into
+the conda environment.
+
+```bash
+$ conda install -c conda-forge --file requirements/conda.txt
+```
+
+### Installing the plugin
+
+This installs the Spyder Vim plugin so that Spyder will use it.
+
+```bash
+$ pip install --no-deps -e .
+```
+
+### Running Spyder
+
+You are done! You can run Spyder as normal and it should load the Vim
+plugin.
+
+```bash
+$ spyder
+```
+
+### Running Tests
+
+This command installs the test dependencies in the conda environment.
+
+```bash
+$ conda install -c conda-forge --file requirements/tests.txt
+```
+
+You can now run the tests with a simple
+
+```bash
+$ pytest
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,97 @@
+# Release
+
+Follow these steps to release a new version of spyder-vim.
+
+In the commands below, replace `X.Y.Z` with the release version when needed.
+
+**Note**: We use `pip` instead of `conda` here even on Conda installs, to ensure we always get the latest upstream versions of the build dependencies.
+
+## PyPI and GitHub
+
+You will need to have a local clone of the repo. The following steps supose a repo setup from a fork with and `upstream` remote pointing to the main `spyder-vim` repo
+
+* Close [milestone on Github](https://github.com/spyder-ide/spyder-vim/milestones)
+
+* Update local repo
+
+  ```bash
+  git restore . && git switch master && git pull upstream master
+  ```
+
+* Clean local repo
+
+  ```bash
+  git clean -xfdi
+  ```
+
+* Install/upgrade Loghub
+
+  ```bash
+  pip install --upgrade loghub
+  ```
+
+* Update `CHANGELOG.md` with Loghub: `loghub spyder-ide/spyder-vim --milestone vX.Y.Z`
+
+* git add and git commit with "Update Changelog"
+
+* Update `__version__` in `__init__.py` (set release version, remove `dev0`)
+
+* Create release commit
+
+  ```bash
+  git commit -am "Release X.Y.Z"
+  ```
+
+* Update the packaging stack
+
+  ```bash
+  python -m pip install --upgrade pip
+  pip install --upgrade --upgrade-strategy eager build setuptools twine wheel
+  ```
+
+* Build source distribution and wheel
+
+  ```bash
+  python -bb -X dev -W error -m build
+  ```
+
+* Check distribution archives
+
+  ```bash
+  twine check --strict dist/*
+  ```
+
+* Upload distribution packages to PyPI
+
+  ```bash
+  twine upload dist/*
+  ```
+
+* Create release tag
+
+  ```bash
+  git tag -a vX.Y.Z -m "Release X.Y.Z"
+  ```
+
+* Update `__version__` in `__init__.py` (add `.dev0` and increment minor)
+
+* Create `Back to work` commit
+
+  ```bash
+  git commit -am "Back to work"
+  ```
+
+* Push new release commits and tags to `master`
+
+  ```bash
+  git push upstream master --follow-tags
+  ```
+
+* Create a [GitHub release](https://github.com/spyder-ide/spyder-vim/releases) from the tag
+
+## Conda-Forge
+
+To release a new version of `spyder-vim` on Conda-Forge:
+
+* After the release on PyPI, an automatic PR in the [Conda-Forge feedstock repo for spyder-vim](https://github.com/conda-forge/spyder-vim-feedstock/pulls) should open.
+  Merging this PR will update the respective Conda-Forge package.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ In the commands below, replace `X.Y.Z` with the release version when needed.
 
 ## PyPI and GitHub
 
-You will need to have a local clone of the repo. The following steps supose a repo setup from a fork with and `upstream` remote pointing to the main `spyder-vim` repo
+You will need to have a local clone of the repo. The following steps suppose a repo setup from a fork with and `upstream` remote pointing to the main `spyder-vim` repo
 
 * Close [milestone on Github](https://github.com/spyder-ide/spyder-vim/milestones)
 


### PR DESCRIPTION
As discussed on #78 some of the missing things to do a release are adding some docs: a contributing guide and some instructions to do a release.

@ok97465 could you give this a review and if it looks good for you approve it and merge it?

You should have write permissions over this repo, so I think you should me able to merge it but let me know if that is not possible :)

Part of #78 
