### PR TITLE
PR: Fix a bug when introducing commands in normal mode

### DIFF
--- a/spyder_vim/spyder/widgets.py
+++ b/spyder_vim/spyder/widgets.py
@@ -1616,7 +1616,7 @@ class VimWidget(QWidget):
             return
         cmd_type = text[0]
         cmd = text[1::].rstrip()
-        if cmd_type == ":":  # Vim command
+        if cmd_type == ":" and 2 <= len(cmd):  # Vim command
             self.vim_commands(text[1:])
         elif cmd_type == "!":  # Shell command
             pass

--- a/spyder_vim/spyder/widgets.py
+++ b/spyder_vim/spyder/widgets.py
@@ -1616,8 +1616,8 @@ class VimWidget(QWidget):
             return
         cmd_type = text[0]
         cmd = text[1::].rstrip()
-        if cmd_type == ":" and 2 <= len(cmd):  # Vim command
-            self.vim_commands(text[1:])
+        if cmd_type == ":":  # Vim command
+            self.vim_commands(cmd)
         elif cmd_type == "!":  # Shell command
             pass
         elif cmd_type == "/":  # Forward search


### PR DESCRIPTION
## Description of the change

I fixed a bug.

## Steps to occur the bug

In the NORMAL mode of Vim, when you only type ":", the Issue reporter shows up.