### PR TITLE
PR: Fix a bug with p command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Spyder project
+.spyproject/

--- a/spyder_vim/spyder/widgets.py
+++ b/spyder_vim/spyder/widgets.py
@@ -1124,7 +1124,9 @@ class VimKeys(QObject):
 
     def p(self, repeat):
         """Paste line below current line, paste characters after cursor."""
+        register = self.register
         __, selection_state = self.get_register(register=self.register)
+        self.register = register
         if selection_state == 'line':
             self._move_cursor(QTextCursor.Down)
             self.P(repeat)

--- a/spyder_vim/spyder/widgets.py
+++ b/spyder_vim/spyder/widgets.py
@@ -1124,18 +1124,16 @@ class VimKeys(QObject):
 
     def p(self, repeat):
         """Paste line below current line, paste characters after cursor."""
-        register = self.register
         __, selection_state = self.get_register(register=self.register)
-        self.register = register
         if selection_state == 'line':
             self._move_cursor(QTextCursor.Down)
             self.P(repeat)
         elif selection_state == 'char':
             self._move_cursor(QTextCursor.Right)
             self.P(repeat)
-        else:
+        elif selection_state == 'block':
             # TODO: implement pasting block text after implementing visual mode
-            self.P()
+            pass
 
     def P(self, repeat):
         """Paste line above current line, paste characters before cursor."""


### PR DESCRIPTION
## Description of Changes

I modified the `p()` function to not run when there is nothing to paste.

## Description of the bug

There was a bug with the p command as reported in issue #86. When there is nothing to paste, more specifically, when executing the p command before any of the d, dd, y, and yy commands, the `P()` function is executed without a required valuable. I noticed that only `char`, `line`, and `block` were expected as values for the `selection_state` parameter in `widgets.py` but it can be `False` as well.

## Issue(s) Resolved

Fixes #86. The issue occurs because `:y` is not implemented yet and doesn't yank anything.
