### PR TITLE
[WIP] PR: Replace `setup.py` with `pyproject.toml` and update spyder constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = {attr = "spyder_vim.__version__"}
+
+[project]
+name = "spyder-vim"
+dynamic = ["version"]
+description = "A plugin to enable vim keybindings to the spyder editor"
+readme = "README.md"
+authors = [
+    {name = "Joseph Martinot-Lagarde and the spyder-vim contributors", email = "spyder.python@gmail.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Text Editors :: Integrated Development Environments (IDE)",
+]
+requires-python = ">= 3.7"
+dependencies = [
+    "qtawesome",
+    "qtpy",
+    "spyder>=6.1.0,<7.0.0",
+]
+license = {text = "MIT license"}
+
+[project.urls]
+Homepage = "https://github.com/spyder-ide/spyder-vim"
+
+[project.entry-points."spyder.plugins"]
+spyder_vim = "spyder_vim.spyder.plugin:SpyderVim"

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -2,4 +2,4 @@ qtawesome
 qtpy
 pip
 setuptools
-spyder>=6.0.0
+spyder>=6.1.0,<7

--- a/setup.py
+++ b/setup.py
@@ -7,52 +7,9 @@
 """
 spyder-vim setup.
 """
-import io
-from setuptools import find_packages
+
+# Third-party imports
 from setuptools import setup
 
-from spyder_vim import __version__
 
-# =============================================================================
-# Use Readme for long description
-# =============================================================================
-with io.open("README.md", encoding="utf-8") as f:
-    LONG_DESCRIPTION = f.read()
-
-setup(
-    # See: https://setuptools.readthedocs.io/en/latest/setuptools.html
-    name="spyder-vim",
-    version=__version__,
-    author="Joseph Martinot-Lagarde and the spyder-vim contributors",
-    author_email="spyder.python@gmail.com",
-    description="A plugin to enable vim keybindings to the spyder editor",
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type="text/markdown",
-    license="MIT license",
-    url="https://github.com/spyder-ide/spyder-vim",
-    python_requires=">= 3.7",
-    install_requires=[
-        "qtpy",
-        "qtawesome",
-        "spyder>=6.0.0",
-    ],
-    packages=find_packages(),
-    entry_points={
-        "spyder.plugins": ["spyder_vim = spyder_vim.spyder.plugin:SpyderVim"],
-    },
-    classifiers=[
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: Developers",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Text Editors :: Integrated Development Environments (IDE)",
-    ],
-)
+setup()

--- a/spyder_vim/spyder/plugin.py
+++ b/spyder_vim/spyder/plugin.py
@@ -46,10 +46,12 @@ class SpyderVim(SpyderPluginV2):
     def get_name():
         return _("spyder-vim")
 
-    def get_description(self):
+    @staticmethod
+    def get_description():
         return _("A plugin to enable vim keybindings to the spyder editor")
 
-    def get_icon(self):
+    @staticmethod
+    def get_icon():
         return QIcon()
 
     def on_initialize(self):


### PR DESCRIPTION
Fixes #98

Requires Spyder 6.1.0 release for the checks to pass and also updates `get_description` and `get_icon` plugin methods to be static (following Spyder 6.1.0 API changes)